### PR TITLE
remove version from docker-compose file

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 x-common-env: &common-env
   MQTT_PUB_INTERVAL: 0
 


### PR DESCRIPTION
When spinning up the Docker Compose setup, the following warning will occur:

time="2025-06-19T10:57:57+08:00" level=warning msg="C:\\...\\Repositories\\ems\\docker-compose\\docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"

Can we just remove the version attribute to prevent this? Or does it have a purpose?